### PR TITLE
fix(app): implement SO_MARK bypass for unblock polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,10 @@ The optional **g0efilter-dashboard** container serves a web UI on port 8081. Set
 
 ![g0efilter-dashboard-example](https://raw.githubusercontent.com/g0lab/g0efilter/main/examples/images/g0efilter-dashboard-example.png)
 
-Remote unblock lets administrators unblock domains/IPs from the dashboard UI. It is disabled by default and must be protected behind authentication middleware. See [docs/remote-unblock.md](docs/remote-unblock.md) for endpoints and a Traefik example.
+Remote unblock lets administrators unblock domains/IPs from the dashboard UI. Instances poll for approved requests and apply them via live reload. It is disabled by default. To enable it, set `ENABLE_REMOTE_UNBLOCK=true` on g0efilter along with `DASHBOARD_HOST` and `DASHBOARD_API_KEY`. See [docs/remote-unblock.md](docs/remote-unblock.md) for setup, endpoints, and a Traefik example.
+
+> [!WARNING]
+> Do not enable remote unblock without protecting `POST /api/v1/unblocks` behind authentication middleware. Anyone who can reach that endpoint can modify your allowlist.
 
 ### Example docker-compose.yaml
 

--- a/docs/remote-unblock.md
+++ b/docs/remote-unblock.md
@@ -5,6 +5,19 @@ Administrators can unblock domains/IPs from the dashboard UI; g0efilter instance
 > [!WARNING]
 > Disabled by default. Only enable behind authentication middleware: `POST /api/v1/unblocks` must be protected (Authelia, Authentik, PocketID, ...) or anyone reaching the dashboard can modify your allowlist.
 
+## Enabling
+
+Set these on **g0efilter** (the dashboard exposes the API-key endpoints automatically, no flag needed):
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ENABLE_REMOTE_UNBLOCK` | yes | Set to `true` to start the poller |
+| `DASHBOARD_HOST` | yes | Dashboard URL (already set for log shipping) |
+| `DASHBOARD_API_KEY` | yes | Must match `API_KEY` on the dashboard |
+| `UNBLOCK_POLL_INTERVAL` | no | Poll interval, default `10s` |
+
+g0efilter logs `remote_unblock.enabled` at startup once all three required values are set. Approved requests are appended to the instance's policy file and applied via live reload.
+
 ## API endpoints
 
 | Endpoint | Auth | Description |

--- a/internal/g0efilter/app.go
+++ b/internal/g0efilter/app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/g0lab/g0efilter/internal/actions"
 	"github.com/g0lab/g0efilter/internal/filter"
 	"github.com/g0lab/g0efilter/internal/logging"
+	"github.com/g0lab/g0efilter/internal/netutil"
 	"github.com/g0lab/g0efilter/internal/nftables"
 	"github.com/g0lab/g0efilter/internal/policy"
 	"github.com/g0lab/g0efilter/internal/procinfo"
@@ -926,6 +927,8 @@ func pollRemoteUnblocks(
 ) {
 	client := &http.Client{
 		Timeout: 10 * time.Second,
+		// SO_MARK bypass so unblock polling is not filtered like client traffic.
+		Transport: &http.Transport{DialContext: netutil.MarkedDialer(10 * time.Second).DialContext},
 	}
 
 	baseURL := cfg.dashboardHost


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added setup guidance for enabling remote unblock, including required and optional configuration settings.
  * Clarified that enabled remote unblock requests are logged and applied automatically.

* **Bug Fixes**
  * Improved remote unblock request handling so polling can work reliably even when normal traffic filtering is in place.

* **Documentation**
  * Added a security warning explaining that remote unblock should be protected by authentication to prevent unauthorized allowlist changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->