### PR TITLE
docs: update policy examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ allowlist:
     - 'github.com'                                 # exact
     - '*.alpinelinux.org'                          # wildcard, any subdomain level
     - 'bucket.*.r2.cloudflarestorage.com'          # wildcard works mid-name too
-    - '/^cache-[0-9]+\.example\.com/'              # regex (single-quote it in YAML)
+    - '/cache-[0-9]+\.example\.com/'              # regex (single-quote it in YAML)
 ```
 
 Each `*` matches one or more characters including dots. Regex entries are slash-delimited, matched case-insensitively against the whole hostname (anchoring is automatic), and compiled with Go's linear-time RE2 engine. Ready-made example policies live in [examples/policy/](https://github.com/g0lab/g0efilter/tree/main/examples/policy).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ g0efilter is a lightweight container that filters outbound (egress) traffic from
 ### Features
 
 - **Egress filtering** by IP/CIDR and domain, default-deny with an allowlist
-- **Flexible domain patterns**: exact names, wildcards anywhere (`*.example.com`, `bucket.*.r2.example.com`), and regex (`/^cache-[0-9]+\.example\.com$/`)
+- **Flexible domain patterns**: exact names, wildcards anywhere (`*.example.com`, `bucket.*.r2.example.com`), and regex (`/cache-[0-9]+\.example\.com/`)
 - **Three filter modes**: `https` (SNI/Host inspection), `dns` (resolution filtering), `dns-strict` (resolution filtering plus kernel connection-time enforcement)
 - **Default-allow (denylist) mode**: allow everything except listed domains/IPs
 - **Learning mode**: observe without blocking and auto-build the allowlist
@@ -35,10 +35,10 @@ Add `policy/policy.yaml`:
 ```yaml
 allowlist:
   ips:
-    - "1.1.1.1"
+    - '1.1.1.1'
   domains:
-    - "github.com"
-    - "*.alpinelinux.org"
+    - 'github.com'
+    - '*.alpinelinux.org'
 ```
 
 Run g0efilter and attach a workload to its network namespace:
@@ -84,13 +84,13 @@ See [docs/modes.md](docs/modes.md) for detailed flow diagrams and mode-specific 
 ```yaml
 allowlist:
   ips:
-    - "1.1.1.1"
-    - "192.168.0.0/16"
+    - '1.1.1.1'
+    - '192.168.0.0/16'
   domains:
-    - "github.com"                                 # exact
-    - "*.alpinelinux.org"                          # wildcard, any subdomain level
-    - "bucket.*.r2.cloudflarestorage.com"          # wildcard works mid-name too
-    - '/^cache-[0-9]+\.example\.com$/'             # regex (single-quote it in YAML)
+    - 'github.com'                                 # exact
+    - '*.alpinelinux.org'                          # wildcard, any subdomain level
+    - 'bucket.*.r2.cloudflarestorage.com'          # wildcard works mid-name too
+    - '/^cache-[0-9]+\.example\.com/'              # regex (single-quote it in YAML)
 ```
 
 Each `*` matches one or more characters including dots. Regex entries are slash-delimited, matched case-insensitively against the whole hostname (anchoring is automatic), and compiled with Go's linear-time RE2 engine. Ready-made example policies live in [examples/policy/](https://github.com/g0lab/g0efilter/tree/main/examples/policy).

--- a/examples/policy/policy-default-allow.yaml
+++ b/examples/policy/policy-default-allow.yaml
@@ -11,14 +11,14 @@ default_action: allow
 # holes in broad wildcard denies.
 allowlist:
   domains:
-    - "api.github.com"                       # explicitly allow this host even though *.github.com is denylisted
+    - 'api.github.com'                       # explicitly allow this host even though *.github.com is denylisted
 
 denylist:
   ips:
-    - "192.168.0.0/16"
+    - '192.168.0.0/16'
   domains:
-    - "*.github.com"                         # deny broad GitHub subdomains
-    - "*.doubleclick.net"                    # analytics
-    - "*.google-analytics.com"
-    - "telemetry.example.com"                # self-update / phone-home checks
-    - '/^update[0-9]*\.example\.com$/'       # regex works in denylists too
+    - '*.github.com'                         # deny broad GitHub subdomains
+    - '*.doubleclick.net'                    # analytics
+    - '*.google-analytics.com'
+    - 'telemetry.example.com'                # self-update / phone-home checks
+    - '/update[0-9]*\.example\.com/'       # regex works in denylists too

--- a/examples/policy/policy.yaml
+++ b/examples/policy/policy.yaml
@@ -4,11 +4,11 @@
 # and README.md in this directory for all supported entry forms.
 allowlist:
   ips:
-    - "1.1.1.1"
-    - "192.168.0.0/16"
-    - "10.1.1.1"
+    - '1.1.1.1'
+    - '192.168.0.0/16'
+    - '10.1.1.1'
   domains:
-    - "github.com"                                   # exact match
-    - "*.alpinelinux.org"                            # wildcard: any subdomain level
-    - "bucket.*.r2.cloudflarestorage.com"            # wildcard works mid-name too
-    - '/^cache-[0-9]+\.example\.com$/'               # regex: single-quote so backslashes survive
+    - 'github.com'                                   # exact match
+    - '*.alpinelinux.org'                            # wildcard: any subdomain level
+    - 'bucket.*.r2.cloudflarestorage.com'            # wildcard works mid-name too
+    - '/cache-[0-9]+\.example\.com/'               # regex: single-quote so backslashes survive


### PR DESCRIPTION
## Summary

Updated policy examples in readme and `/examples/policy`.

- Changed double quotes to single for consistency (previously, single quotes were only used on regex examples to avoid complications around escaping, but I don't think there's any reason to make people think about which one to use)
- Removed redundant regex anchors since patterns are automatically anchored to the entire string

## Validation

N/A - Docs only

## Reviewer Notes

No worries if you want to keep the double/single quotes divide; I just think this is simpler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README and policy examples to use consistent YAML quoting for IP, domain, and pattern entries.
  * Clarified regex examples to better match the documented behavior of automatic anchoring.
  * Refreshed sample policy files so configuration examples are easier to copy and apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->