### PR TITLE
fix(alerting): gate notifications on explicit alert flag, fixing DNS false positives

### DIFF
--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -17,3 +17,9 @@ const (
 	// allowed domains are pushed into a kernel timeout set and everything else drops.
 	ModeDNSStrict = "dns-strict"
 )
+
+// KeyAlert is the structured-log attribute a producer sets to true to mark a
+// record as a genuine enforcement event worth a notification. Alerting keys off
+// this flag, not the action label, so audit-mode or benign events that carry a
+// block-shaped action never page.
+const KeyAlert = "alert"

--- a/internal/filter/common.go
+++ b/internal/filter/common.go
@@ -779,6 +779,10 @@ func logPolicyViolation(
 	fields := baseLogFields(component, action, identifier, sourceIP, sourcePort)
 	fields = append(fields, "reason", reason)
 
+	if action == actions.ActionBlocked {
+		fields = append(fields, actions.KeyAlert, true)
+	}
+
 	if destIP != "" {
 		flowID := actions.FlowID(sourceIP, sourcePort, destIP, destPort, "tcp")
 		fields = append(fields,

--- a/internal/filter/common_test.go
+++ b/internal/filter/common_test.go
@@ -751,11 +751,19 @@ func TestDecisionLogLevels(t *testing.T) {
 		t.Errorf("blocked connection must log at WARN, got: %s", buf.String())
 	}
 
+	if !strings.Contains(buf.String(), `"alert":true`) {
+		t.Errorf("blocked connection must flag an alert, got: %s", buf.String())
+	}
+
 	buf, opts = newCapture()
 	logAuditedConnection(opts, "https", "not-allowlisted", "evil.com", conn1, "1.2.3.4", 443)
 
 	if !strings.Contains(buf.String(), `"level":"WARN"`) {
 		t.Errorf("audited connection must log at WARN, got: %s", buf.String())
+	}
+
+	if strings.Contains(buf.String(), `"alert":true`) {
+		t.Errorf("audited (would-be-block) connection must not flag an alert, got: %s", buf.String())
 	}
 
 	buf, opts = newCapture()

--- a/internal/filter/dns_filter.go
+++ b/internal/filter/dns_filter.go
@@ -541,21 +541,28 @@ func (handler *dnsHandler) handleBlockedEnforcedType(
 
 	message := new(dns.Msg)
 	message.SetReply(request)
-
-	switch qtype {
-	case dns.TypeA:
-		message.Answer = append(message.Answer, &dns.A{
-			Hdr: dns.RR_Header{Name: request.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: defaultTTL},
-			A:   net.IPv4(0, 0, 0, 0),
-		})
-	case dns.TypeAAAA:
-		message.Answer = append(message.Answer, &dns.AAAA{
-			Hdr:  dns.RR_Header{Name: request.Question[0].Name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: defaultTTL},
-			AAAA: net.IPv6zero,
-		})
-	}
+	message.Answer = sinkholeAnswer(request.Question[0].Name, qtype)
 
 	_ = writer.WriteMsg(message)
+}
+
+// sinkholeAnswer builds the zero-address record (0.0.0.0 / ::) used to sinkhole
+// an A/AAAA query without leaking a real IP.
+func sinkholeAnswer(name string, qtype uint16) []dns.RR {
+	switch qtype {
+	case dns.TypeA:
+		return []dns.RR{&dns.A{
+			Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: defaultTTL},
+			A:   net.IPv4(0, 0, 0, 0),
+		}}
+	case dns.TypeAAAA:
+		return []dns.RR{&dns.AAAA{
+			Hdr:  dns.RR_Header{Name: name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: defaultTTL},
+			AAAA: net.IPv6zero,
+		}}
+	default:
+		return nil
+	}
 }
 
 // handleBlockedNonEnforcedType handles blocked non-A/AAAA queries by responding with NXDOMAIN.
@@ -662,10 +669,10 @@ func (handler *dnsHandler) resolveViaIPAllowlist(
 	if len(kept) == 0 {
 		// No allowlisted IP for this record type. If the domain reaches an
 		// allowlisted IP via the other address family (e.g. an AAAA probe for an
-		// IPv4-only allowlisted host), the sinkhole here is expected: answer
-		// NODATA rather than raising a false BLOCKED alert.
+		// IPv4-only allowlisted host), the sinkhole here is expected: answer it
+		// without raising a false BLOCKED alert.
 		if handler.siblingResolvesToAllowlistedIP(qname, qtype) {
-			handler.answerNoData(lg, writer, request, qname, qtype, remoteAddr, remotePort, flowID)
+			handler.answerSinkholeSibling(lg, writer, request, qname, qtype, remoteAddr, remotePort, flowID)
 
 			return true
 		}
@@ -720,9 +727,13 @@ func siblingQtype(qtype uint16) uint16 {
 	}
 }
 
-// answerNoData replies NOERROR with no records: the domain is reachable via the
-// other address family, so this record type simply has nothing to return.
-func (handler *dnsHandler) answerNoData(
+// answerSinkholeSibling replies to an A/AAAA query whose own family has no
+// allowlisted IP but whose sibling family does. It returns the zero-address
+// sinkhole (0.0.0.0 / ::) rather than an empty NODATA answer: a positive answer
+// stops the stub resolver from walking its search list, which would otherwise
+// emit spurious BLOCKED alerts for suffixed names. The host is reachable via the
+// sibling family, so this logs ALLOWED without an alert.
+func (handler *dnsHandler) answerSinkholeSibling(
 	lg *slog.Logger,
 	writer dns.ResponseWriter,
 	request *dns.Msg,
@@ -738,9 +749,11 @@ func (handler *dnsHandler) answerNoData(
 		lg.Info("dns.allowed", fields...)
 	}
 
-	reply := new(dns.Msg)
-	reply.SetReply(request)
-	_ = writer.WriteMsg(reply)
+	message := new(dns.Msg)
+	message.SetReply(request)
+	message.Answer = sinkholeAnswer(request.Question[0].Name, qtype)
+
+	_ = writer.WriteMsg(message)
 }
 
 // filterToAllowlistedIPs keeps only the A/AAAA answer records whose address is in

--- a/internal/filter/dns_filter.go
+++ b/internal/filter/dns_filter.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/g0lab/g0efilter/internal/actions"
 	"github.com/g0lab/g0efilter/internal/netutil"
 	"github.com/miekg/dns"
 )
@@ -445,7 +446,8 @@ func (handler *dnsHandler) blockExfilResponse(
 }
 
 // dnsLogFields builds the shared decision-log fields for DNS queries, including
-// process attribution when enabled.
+// process attribution when enabled. BLOCKED records are flagged for alerting;
+// ALLOWED/AUDIT records are not.
 func (handler *dnsHandler) dnsLogFields(
 	action, qname string,
 	qtype uint16,
@@ -465,6 +467,10 @@ func (handler *dnsHandler) dnsLogFields(
 		"source_port", remotePort,
 		"flow_id", flowID,
 	)
+
+	if action == actions.ActionBlocked {
+		fields = append(fields, actions.KeyAlert, true)
+	}
 
 	return append(fields, procFields(handler.opts, remoteAddr, remotePort, "udp")...)
 }
@@ -654,6 +660,16 @@ func (handler *dnsHandler) resolveViaIPAllowlist(
 
 	kept := handler.filterToAllowlistedIPs(resp)
 	if len(kept) == 0 {
+		// No allowlisted IP for this record type. If the domain reaches an
+		// allowlisted IP via the other address family (e.g. an AAAA probe for an
+		// IPv4-only allowlisted host), the sinkhole here is expected: answer
+		// NODATA rather than raising a false BLOCKED alert.
+		if handler.siblingResolvesToAllowlistedIP(qname, qtype) {
+			handler.answerNoData(lg, writer, request, qname, qtype, remoteAddr, remotePort, flowID)
+
+			return true
+		}
+
 		return false
 	}
 
@@ -670,6 +686,61 @@ func (handler *dnsHandler) resolveViaIPAllowlist(
 	_ = writer.WriteMsg(reply)
 
 	return true
+}
+
+// siblingResolvesToAllowlistedIP reports whether qname resolves to an allowlisted
+// IP in the other address family (A<->AAAA). A per-family sinkhole stays silent
+// when the domain is still reachable, so a dual-stack client's unmatched query
+// does not raise a false BLOCKED alert.
+func (handler *dnsHandler) siblingResolvesToAllowlistedIP(qname string, qtype uint16) bool {
+	sibling := siblingQtype(qtype)
+	if sibling == 0 {
+		return false
+	}
+
+	req := new(dns.Msg)
+	req.SetQuestion(dns.Fqdn(qname), sibling)
+
+	resp, err := handler.forward(req)
+	if err != nil || resp == nil {
+		return false
+	}
+
+	return len(handler.filterToAllowlistedIPs(resp)) > 0
+}
+
+func siblingQtype(qtype uint16) uint16 {
+	switch qtype {
+	case dns.TypeA:
+		return dns.TypeAAAA
+	case dns.TypeAAAA:
+		return dns.TypeA
+	default:
+		return 0
+	}
+}
+
+// answerNoData replies NOERROR with no records: the domain is reachable via the
+// other address family, so this record type simply has nothing to return.
+func (handler *dnsHandler) answerNoData(
+	lg *slog.Logger,
+	writer dns.ResponseWriter,
+	request *dns.Msg,
+	qname string,
+	qtype uint16,
+	remoteAddr string,
+	remotePort int,
+	flowID string,
+) {
+	if lg != nil {
+		fields := handler.dnsLogFields("ALLOWED", qname, qtype, remoteAddr, remotePort, flowID)
+		fields = append(fields, "note", "ip-allowlisted-other-family")
+		lg.Info("dns.allowed", fields...)
+	}
+
+	reply := new(dns.Msg)
+	reply.SetReply(request)
+	_ = writer.WriteMsg(reply)
 }
 
 // filterToAllowlistedIPs keeps only the A/AAAA answer records whose address is in

--- a/internal/filter/dns_ip_allowlist_test.go
+++ b/internal/filter/dns_ip_allowlist_test.go
@@ -2,11 +2,47 @@
 package filter
 
 import (
+	"bytes"
+	"context"
+	"log/slog"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/miekg/dns"
 )
+
+// startTestUpstream runs a UDP DNS server answering from records keyed by
+// "<qname>/<qtype>" (e.g. "host.example./AAAA"). It returns the listen address
+// for handler.upstreams.
+func startTestUpstream(t *testing.T, records map[string][]dns.RR) string {
+	t.Helper()
+
+	var lc net.ListenConfig
+
+	pc, err := lc.ListenPacket(context.Background(), "udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen upstream: %v", err)
+	}
+
+	srv := &dns.Server{PacketConn: pc, Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		reply := new(dns.Msg)
+		reply.SetReply(r)
+
+		if len(r.Question) > 0 {
+			q := r.Question[0]
+			reply.Answer = records[q.Name+"/"+typeString(q.Qtype)]
+		}
+
+		_ = w.WriteMsg(reply)
+	})} //nolint:exhaustruct
+
+	go func() { _ = srv.ActivateAndServe() }()
+
+	t.Cleanup(func() { _ = srv.Shutdown() })
+
+	return pc.LocalAddr().String()
+}
 
 func TestIPAllowlistContains(t *testing.T) {
 	t.Parallel()
@@ -120,5 +156,138 @@ func TestResolveViaIPAllowlistNoIPsSkips(t *testing.T) {
 
 	if len(writer.responses) != 0 {
 		t.Errorf("expected no response written, got %d", len(writer.responses))
+	}
+}
+
+// TestSiblingResolvesToAllowlistedIP proves an AAAA miss consults the A family
+// (and vice versa) so a dual-stack host allowlisted by one family is reachable.
+func TestSiblingResolvesToAllowlistedIP(t *testing.T) {
+	t.Parallel()
+
+	name := "dualstack.example."
+	up := startTestUpstream(t, map[string][]dns.RR{
+		name + "/A":    {answerA(name, "40.89.244.232", 60)},
+		name + "/AAAA": {answerAAAA(name, "2606:4700::1", 60)},
+	})
+
+	handler := createDNSHandler(nil, Options{}) //nolint:exhaustruct
+	handler.ipAllow = newIPAllowlist([]string{"40.89.244.232"})
+	handler.upstreams = []string{up}
+
+	if !handler.siblingResolvesToAllowlistedIP("dualstack.example", dns.TypeAAAA) {
+		t.Error("AAAA query: expected sibling A to be allowlisted")
+	}
+
+	if handler.siblingResolvesToAllowlistedIP("dualstack.example", dns.TypeA) {
+		t.Error("A query: sibling AAAA is not allowlisted, want false")
+	}
+
+	if handler.siblingResolvesToAllowlistedIP("dualstack.example", dns.TypeMX) {
+		t.Error("non-address qtype has no sibling, want false")
+	}
+}
+
+// TestResolveViaIPAllowlistSiblingNoData proves the false-positive fix: an AAAA
+// probe for an IPv4-only allowlisted host is answered NODATA (NOERROR, no
+// records), not sinkholed, so no BLOCKED alert fires.
+func TestResolveViaIPAllowlistSiblingNoData(t *testing.T) {
+	t.Parallel()
+
+	name := "dualstack.example."
+	up := startTestUpstream(t, map[string][]dns.RR{
+		name + "/A":    {answerA(name, "40.89.244.232", 60)},
+		name + "/AAAA": {answerAAAA(name, "2606:4700::1", 60)},
+	})
+
+	handler := createDNSHandler(nil, Options{}) //nolint:exhaustruct
+	handler.ipAllow = newIPAllowlist([]string{"40.89.244.232"})
+	handler.upstreams = []string{up}
+
+	writer := &mockDNSResponseWriter{responses: make([]*dns.Msg, 0)} //nolint:exhaustruct
+	msg := new(dns.Msg)
+	msg.SetQuestion(name, dns.TypeAAAA)
+
+	if !handler.resolveViaIPAllowlist(nil, writer, msg, "dualstack.example", dns.TypeAAAA, "1.1.1.1", 1234, "flow") {
+		t.Fatal("expected AAAA to be handled via sibling IP allowlist")
+	}
+
+	if len(writer.responses) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(writer.responses))
+	}
+
+	resp := writer.responses[0]
+	if resp.Rcode != dns.RcodeSuccess {
+		t.Errorf("rcode = %d, want NOERROR", resp.Rcode)
+	}
+
+	if len(resp.Answer) != 0 {
+		t.Errorf("expected NODATA (0 answers), got %d", len(resp.Answer))
+	}
+}
+
+// TestHandleAAAASiblingLogsAllowedNotBlocked drives the full handler and asserts
+// the dual-stack AAAA probe logs ALLOWED, never the BLOCKED event that would
+// trigger a notification.
+func TestHandleAAAASiblingLogsAllowedNotBlocked(t *testing.T) {
+	t.Parallel()
+
+	name := "dualstack.example."
+	up := startTestUpstream(t, map[string][]dns.RR{
+		name + "/A":    {answerA(name, "40.89.244.232", 60)},
+		name + "/AAAA": {answerAAAA(name, "2606:4700::1", 60)},
+	})
+
+	var buf bytes.Buffer
+
+	handler := createDNSHandler(nil, Options{Logger: slog.New(slog.NewJSONHandler(&buf, nil))}) //nolint:exhaustruct
+	handler.ipAllow = newIPAllowlist([]string{"40.89.244.232"})
+	handler.upstreams = []string{up}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion(name, dns.TypeAAAA)
+	handler.handle(&mockDNSResponseWriter{responses: make([]*dns.Msg, 0)}, msg) //nolint:exhaustruct
+
+	logged := buf.String()
+	if strings.Contains(logged, "dns.blocked") || strings.Contains(logged, `"action":"BLOCKED"`) {
+		t.Errorf("dual-stack AAAA must not emit a BLOCKED event, got: %s", logged)
+	}
+
+	if strings.Contains(logged, `"alert":true`) {
+		t.Errorf("benign sibling sinkhole must not flag an alert, got: %s", logged)
+	}
+
+	if !strings.Contains(logged, "ip-allowlisted-other-family") {
+		t.Errorf("expected ip-allowlisted-other-family note, got: %s", logged)
+	}
+}
+
+// TestHandleAAAANeitherFamilyBlocks proves a genuine block still alerts: when no
+// family resolves to an allowlisted IP the AAAA query is sinkholed and BLOCKED.
+func TestHandleAAAANeitherFamilyBlocks(t *testing.T) {
+	t.Parallel()
+
+	name := "evil.example."
+	up := startTestUpstream(t, map[string][]dns.RR{
+		name + "/A":    {answerA(name, "203.0.113.7", 60)},
+		name + "/AAAA": {answerAAAA(name, "2606:4700::1", 60)},
+	})
+
+	var buf bytes.Buffer
+
+	handler := createDNSHandler(nil, Options{Logger: slog.New(slog.NewJSONHandler(&buf, nil))}) //nolint:exhaustruct
+	handler.ipAllow = newIPAllowlist([]string{"40.89.244.232"})
+	handler.upstreams = []string{up}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion(name, dns.TypeAAAA)
+	handler.handle(&mockDNSResponseWriter{responses: make([]*dns.Msg, 0)}, msg) //nolint:exhaustruct
+
+	logged := buf.String()
+	if !strings.Contains(logged, "dns.blocked") {
+		t.Errorf("expected dns.blocked for a domain with no allowlisted IP, got: %s", logged)
+	}
+
+	if !strings.Contains(logged, `"alert":true`) {
+		t.Errorf("genuine block must flag an alert, got: %s", logged)
 	}
 }

--- a/internal/filter/dns_ip_allowlist_test.go
+++ b/internal/filter/dns_ip_allowlist_test.go
@@ -188,9 +188,10 @@ func TestSiblingResolvesToAllowlistedIP(t *testing.T) {
 }
 
 // TestResolveViaIPAllowlistSiblingNoData proves the false-positive fix: an AAAA
-// probe for an IPv4-only allowlisted host is answered NODATA (NOERROR, no
-// records), not sinkholed, so no BLOCKED alert fires.
-func TestResolveViaIPAllowlistSiblingNoData(t *testing.T) {
+// probe for an IPv4-only allowlisted host is answered with the zero-address
+// sinkhole (not empty NODATA, which would make the resolver walk its search
+// list), so the host stays reachable via IPv4 and no BLOCKED alert fires.
+func TestResolveViaIPAllowlistSiblingSinkhole(t *testing.T) {
 	t.Parallel()
 
 	name := "dualstack.example."
@@ -220,8 +221,13 @@ func TestResolveViaIPAllowlistSiblingNoData(t *testing.T) {
 		t.Errorf("rcode = %d, want NOERROR", resp.Rcode)
 	}
 
-	if len(resp.Answer) != 0 {
-		t.Errorf("expected NODATA (0 answers), got %d", len(resp.Answer))
+	if len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 sinkhole answer, got %d", len(resp.Answer))
+	}
+
+	aaaa, ok := resp.Answer[0].(*dns.AAAA)
+	if !ok || !aaaa.AAAA.Equal(net.IPv6zero) {
+		t.Errorf("expected :: sinkhole answer, got %v", resp.Answer[0])
 	}
 }
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -542,7 +542,7 @@ func (z *zerologHandler) Handle(ctx context.Context, record slog.Record) error {
 		shipToDashboard(z.poster, z.hostname, z.version, record.Time, record.Message, act, attrs)
 	}
 
-	if z.notifier != nil && act == actions.ActionBlocked {
+	if z.notifier != nil && shouldAlert(attrs) {
 		handleBlockedAlert(ctx, z.notifier, attrs)
 	}
 
@@ -600,6 +600,19 @@ func shouldShipToDashboard(act string, attrs map[string]any) bool {
 	return true
 }
 
+// shouldAlert reports whether a record is a genuine enforcement event that
+// warrants a notification. Producers mark these with alert=true; the terminal
+// action label (BLOCKED/ALLOWED/AUDIT) drives logging and the dashboard, not paging.
+func shouldAlert(attrs map[string]any) bool {
+	if v, ok := attrs[actions.KeyAlert]; ok {
+		b, _ := v.(bool)
+
+		return b
+	}
+
+	return false
+}
+
 func extractAction(attrs map[string]any) string {
 	if v, ok := attrs[keyAction]; ok {
 		return strings.ToUpper(fmt.Sprint(v))
@@ -645,8 +658,8 @@ func shipToDashboard(
 	}
 }
 
-// handleBlockedAlert processes BLOCKED events and sends notifications.
-// The caller must ensure act == "BLOCKED" before calling.
+// handleBlockedAlert builds and sends a notification for an alert-flagged event.
+// The caller must ensure the record set alert=true before calling.
 func handleBlockedAlert(ctx context.Context, notifier *alerting.Notifier, attrs map[string]any) {
 	// Extract detailed connection information
 	info := alerting.BlockedConnectionInfo{

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -859,6 +859,31 @@ func mkTestPoster() (*poster, chan []byte) {
 	return p, ch
 }
 
+func TestShouldAlert(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		attrs map[string]any
+		want  bool
+	}{
+		{"alert true", map[string]any{"alert": true}, true},
+		{"alert false", map[string]any{"alert": false}, false},
+		{"no alert key", map[string]any{"action": "BLOCKED"}, false},
+		{"alert not a bool", map[string]any{"alert": "true"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := shouldAlert(tt.attrs); got != tt.want {
+				t.Errorf("shouldAlert(%v) = %v, want %v", tt.attrs, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestShipToDashboard_ActionFilters(t *testing.T) {
 	t.Parallel()
 
@@ -1192,6 +1217,7 @@ func TestAlertingIntegration(t *testing.T) {
 	logger.InfoContext(ctx, "dns.blocked",
 		"component", "dns",
 		"action", "BLOCKED",
+		"alert", true,
 		"qname", "malicious.com",
 		"qtype", "A",
 		"source_ip", "192.168.1.100",
@@ -1315,8 +1341,10 @@ func TestAlertingDisabled(t *testing.T) {
 	// Test passes if no panic occurs
 }
 
-func TestAlertingOnlyBlockedEvents(t *testing.T) {
-	// Test that only BLOCKED events trigger notifications
+// TestAlertingKeyedOnAlertFlag proves notifications are driven by the alert flag,
+// not the action label: a benign event that carries a BLOCKED-shaped action but
+// no alert flag must not page, while an alert-flagged event always does.
+func TestAlertingKeyedOnAlertFlag(t *testing.T) {
 	var notificationCount atomic.Int64
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -1332,16 +1360,17 @@ func TestAlertingOnlyBlockedEvents(t *testing.T) {
 
 	logger := NewWithContext(context.Background(), "DEBUG", io.Discard, "test-version")
 
-	// Test various actions - only BLOCKED should trigger notification
 	testCases := []struct {
+		name     string
 		action   string
+		alert    bool
 		expected bool
 	}{
-		{"BLOCKED", true},
-		{"ALLOWED", false},
-		{"REDIRECTED", false},
-		{"ERROR", false},
-		{"blocked", true}, // case insensitive
+		{"blocked with alert flag", "BLOCKED", true, true},
+		{"blocked without alert flag", "BLOCKED", false, false},
+		{"allowed with alert flag", "ALLOWED", true, true},
+		{"allowed without alert flag", "ALLOWED", false, false},
+		{"audit without alert flag", "AUDIT", false, false},
 	}
 
 	for i, tc := range testCases {
@@ -1353,6 +1382,7 @@ func TestAlertingOnlyBlockedEvents(t *testing.T) {
 
 		logger.Info("test.event",
 			"action", tc.action,
+			"alert", tc.alert,
 			"source_ip", sourceIP,
 			"destination_ip", destIP,
 		)
@@ -1362,11 +1392,11 @@ func TestAlertingOnlyBlockedEvents(t *testing.T) {
 
 		count := notificationCount.Load()
 		if tc.expected && count == 0 {
-			t.Errorf("Expected notification for action %s but none received", tc.action)
+			t.Errorf("%s: expected notification but none received", tc.name)
 		}
 
 		if !tc.expected && count > 0 {
-			t.Errorf("Unexpected notification for action %s", tc.action)
+			t.Errorf("%s: unexpected notification", tc.name)
 		}
 	}
 }
@@ -1395,6 +1425,7 @@ func TestAlertingBelowTerminalLevel(t *testing.T) {
 	logger.WarnContext(ctx, "https.blocked",
 		"component", "https",
 		"action", "BLOCKED",
+		"alert", true,
 		"https", "evil.example.com",
 		"source_ip", "192.168.1.100",
 		"source_port", 12345,

--- a/internal/nftables/nftables.go
+++ b/internal/nftables/nftables.go
@@ -1161,6 +1161,10 @@ func processActionEvent(
 	)
 	fields = append(fields, "action", action)
 
+	if action == actions.ActionBlocked {
+		fields = append(fields, actions.KeyAlert, true)
+	}
+
 	// Level policy: REDIRECTED and ALLOWED at DEBUG, BLOCKED at WARN
 	if action == actions.ActionRedirected || action == actions.ActionAllowed {
 		lg.Debug("nflog.event", fields...)

--- a/internal/nftables/nftables_test.go
+++ b/internal/nftables/nftables_test.go
@@ -1061,6 +1061,10 @@ func TestProcessActionEventLevels(t *testing.T) {
 		t.Errorf("BLOCKED nflog event must log at WARN, got: %s", buf.String())
 	}
 
+	if !strings.Contains(buf.String(), `"alert":true`) {
+		t.Errorf("BLOCKED nflog event must flag an alert, got: %s", buf.String())
+	}
+
 	buf.Reset()
 	processActionEvent(logger, "ALLOWED", "flow-2", pkt, 64)
 

--- a/tests/e2e/01_baseline.sh
+++ b/tests/e2e/01_baseline.sh
@@ -17,12 +17,19 @@ fi
 assert_blocked https://google.com
 assert_blocked http://google.com
 
-log "[Log level] Blocked decisions must log at WARN"
-if ! $COMPOSE logs g0efilter | sed 's/\x1b\[[0-9;]*m//g' | grep -E "WRN.*\.blocked" | grep -q "action=BLOCKED"; then
+log "[Log level] Blocked decisions must log at WARN and be alert-flagged"
+blocked_line=$($COMPOSE logs g0efilter | strip_ansi | grep -E "WRN.*\.blocked" | grep "action=BLOCKED" || true)
+if [ -z "$blocked_line" ]; then
   dump_logs
   fail "no WRN-level blocked log line found (blocked decisions must log at WARN)"
 fi
-log "OK: blocked decisions log at WARN"
+# The genuine block must carry the alert flag in every mode; if a producer stops
+# flagging it the notification is silently lost (false negative).
+if printf '%s\n' "$blocked_line" | grep -v "alert=true" | grep -q .; then
+  dump_logs
+  fail "blocked decision is not alert-flagged in $FILTER_MODE mode (missed alert / false negative)"
+fi
+log "OK: blocked decisions log at WARN and are alert-flagged"
 
 if [ "$FILTER_MODE" = "https" ]; then
   assert_blocked https://1.0.0.1

--- a/tests/e2e/13_dns_ip_allowlist.sh
+++ b/tests/e2e/13_dns_ip_allowlist.sh
@@ -27,8 +27,18 @@ wait_ready
 log "[IP-allowlist] Non-allowlisted domain pointing at an allowlisted IP resolves and connects"
 assert_allowed https://one.one.one.one
 
+# one.one.one.one is dual-stack but only its IPv4 is allowlisted: the unmatched
+# AAAA must sinkhole silently, never log a block or raise an alert.
+log "[IP-allowlist] Dual-stack host allowlisted by IPv4 only does not false-alert on AAAA"
+assert_no_dns_block one.one.one.one
+
 log "[IP-allowlist] Domain not resolving to an allowlisted IP stays blocked"
 assert_blocked https://example.com
+
+# The genuine block must still raise an alert: its dns.blocked event carries the
+# alert flag. Guards the opposite of the AAAA case above (missed alert).
+log "[IP-allowlist] Genuine block is logged and alert-flagged"
+assert_dns_block_alerts example.com
 
 log "[IP-allowlist] Directly allowlisted IP still works"
 assert_allowed https://1.1.1.1

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -121,8 +121,10 @@ assert_blocked() {
 # qname. Guards against the dual-stack false positive where an unmatched AAAA of
 # an IP-allowlisted host was sinkholed and paged.
 assert_no_dns_block() {
-  local qname="$1"
-  if $COMPOSE logs g0efilter 2>/dev/null | strip_ansi | grep "dns.blocked" | grep -q "$qname"; then
+  local qname="$1" re
+  re="qname=${qname//./\\.}( |$)" # exact qname; a search-suffixed variant must not match
+  sleep 2                         # let a would-be AAAA block log flush before asserting its absence
+  if $COMPOSE logs g0efilter 2>/dev/null | strip_ansi | grep "dns.blocked" | grep -Eq "$re"; then
     dump_logs
     fail "false-positive dns.blocked logged for $qname"
   fi
@@ -133,9 +135,10 @@ assert_no_dns_block() {
 # event for qname carrying alert=true. Guards against a genuine block silently
 # losing its notification (false negative) if a producer stops flagging alerts.
 assert_dns_block_alerts() {
-  local qname="$1"
+  local qname="$1" re
+  re="qname=${qname//./\\.}( |$)"
   for _ in $(seq 1 10); do
-    if $COMPOSE logs g0efilter 2>/dev/null | strip_ansi | grep "dns.blocked" | grep "$qname" | grep -q "alert=true"; then
+    if $COMPOSE logs g0efilter 2>/dev/null | strip_ansi | grep "dns.blocked" | grep -E "$re" | grep -q "alert=true"; then
       log "OK: dns.blocked for $qname is alert-flagged"
       return 0
     fi

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -13,6 +13,10 @@ FILTER_MODE="${FILTER_MODE:-https}"
 log()  { echo "[e2e] $*"; }
 fail() { echo "[e2e] ERROR: $*" >&2; exit 1; }
 
+# g0efilter's console logger colorizes output, so a key and value are split by an
+# ANSI reset (alert=<ESC>true). Strip escapes before grepping structured fields.
+strip_ansi() { sed "s/$(printf '\033')\[[0-9;]*m//g"; }
+
 # Baseline for reload detection: phases run as separate processes, so capture the
 # current count at source time (0 when the stack isn't up yet).
 RELOAD_BASE=$($COMPOSE logs g0efilter 2>/dev/null | grep -c "policy.applied" || true)
@@ -111,6 +115,34 @@ assert_blocked() {
     fail "$url was allowed but should be blocked"
   fi
   log "OK: $url blocked"
+}
+
+# assert_no_dns_block <qname>: fail if g0efilter logged a dns.blocked event for
+# qname. Guards against the dual-stack false positive where an unmatched AAAA of
+# an IP-allowlisted host was sinkholed and paged.
+assert_no_dns_block() {
+  local qname="$1"
+  if $COMPOSE logs g0efilter 2>/dev/null | strip_ansi | grep "dns.blocked" | grep -q "$qname"; then
+    dump_logs
+    fail "false-positive dns.blocked logged for $qname"
+  fi
+  log "OK: no dns.blocked logged for $qname"
+}
+
+# assert_dns_block_alerts <qname>: fail unless g0efilter logged a dns.blocked
+# event for qname carrying alert=true. Guards against a genuine block silently
+# losing its notification (false negative) if a producer stops flagging alerts.
+assert_dns_block_alerts() {
+  local qname="$1"
+  for _ in $(seq 1 10); do
+    if $COMPOSE logs g0efilter 2>/dev/null | strip_ansi | grep "dns.blocked" | grep "$qname" | grep -q "alert=true"; then
+      log "OK: dns.blocked for $qname is alert-flagged"
+      return 0
+    fi
+    sleep 1
+  done
+  dump_logs
+  fail "expected an alert-flagged dns.blocked for $qname (missed alert / false negative)"
 }
 
 # wait_for_policy_reload: g0efilter polls the policy file every 5s. Waits for a


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now trigger based on a dedicated alert flag for genuine blocked events (not just the block action label).
  * Blocked events and enforcement logs are more explicitly tagged for clearer alerting and auditing.

* **Bug Fixes**
  * Dual-stack/sibling DNS allowlist behavior was improved to avoid false blocks when the host is allowlisted in the other address family.
  * Correct NODATA-style sinkhole handling is used for certain sibling lookups to prevent unintended resolver behavior.

* **Tests**
  * Enhanced unit and end-to-end checks to verify the alert flag is present (or absent) as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->